### PR TITLE
Fixes pandas citation in bib

### DIFF
--- a/joss/paper.bib
+++ b/joss/paper.bib
@@ -71,7 +71,7 @@
 }
 
 @software{pandas,
-    author       = {{Reback,  Jeff and McKinney,  Wes and {Jbrockmendel} and Bossche,  Joris Van Den and Augspurger,  Tom and Cloud,  Phillip and {Gfyoung} and Hawkins,  Simon and {Sinhrks} and Roeschke,  Matthew and Klein,  Adam and {Terji Petersen} and Tratner,  Jeff and She,  Chang and Ayd,  William and Naveh,  Shahar and Garcia,  Marc and {,  Patrick} and Schendel,  Jeremy and Hayden,  Andy and Saxton,  Daniel and Jancauskas,  Vytautas and Shadrach,  Richard and Gorelli,  Marco and McMaster,  Ali and Battiston,  Pietro and {Skipper Seabold} and {Kaiqi Dong} and {chris-b1} and {h-vetinari}}},
+    author       = {Reback, Jeff and McKinney, Wes and {Jbrockmendel} and Bossche, Joris Van Den and Augspurger, Tom and Cloud, Phillip and {Gfyoung} and Hawkins, Simon and {Sinhrks} and Roeschke, Matthew and Klein, Adam and Petersen, Terji and Tratner, Jeff and She, Chang and Ayd, William and Naveh, Shahar and Garcia, Marc and {Patrick} and Schendel, Jeremy and Hayden, Andy and Saxton, Daniel and Jancauskas, Vytautas and Shadrach, Richard and Gorelli, Marco and McMaster, Ali and Battiston, Pietro and Seabold, Skipper and Dong, Kaiqi and {chris-b1} and {h-vetinari}},
     title        = {pandas-dev/pandas: Pandas},
     month        = mar,
     year         = 2021,


### PR DESCRIPTION
# Description
Fixes the pandas citation for the JOSS paper. The past commit/PR unintentionally left double curly brackets.
